### PR TITLE
Caff 2 - Simulate IMU

### DIFF
--- a/robot/description/urdf/caffeine.gazebo.xacro
+++ b/robot/description/urdf/caffeine.gazebo.xacro
@@ -77,19 +77,19 @@
     <gazebo>
         <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
             <robotNamespace>${robotNamespace}</robotNamespace>
-            <updateRate>5.0</updateRate>  <!-- 5 Hz -->
-            <bodyName>${tf_prefix}/gps_link</bodyName>
-            <frameId>${tf_prefix}/gps_link</frameId>
-            <topicName>gps/fix</topicName>
-            <velocityTopicName>gps/fix_velocity</velocityTopicName>
-            <!-- Set reference GPS coordinates to UofT -->
-            <referenceLatitude>43.6570</referenceLatitude>
-            <referenceLongitude>-79.3903</referenceLongitude>
-            <referenceAltitude>76</referenceAltitude>
-            <!-- Model GPS behaviour -->
-            <service>1</service> <!-- SERVICE_GPS = 1 -->
-            <drift>1.5 1.5 1.5</drift> <!-- m -->
-            <velocityDrift>0.05 0.05 0.05</velocityDrift> <!-- m/s-->
+            <updateRate>${gps_update_rate}</updateRate>
+            <bodyName>${tf_prefix}/${gps_frame}</bodyName>
+            <frameId>${tf_prefix}/${gps_frame}</frameId>
+
+            <topicName>${gps_topic}</topicName>
+            <velocityTopicName>${gps_vel_topic}</velocityTopicName>
+            
+            <referenceLatitude>${ref_lat}</referenceLatitude>
+            <referenceLongitude>${ref_lon}</referenceLongitude>
+            <referenceAltitude>${ref_alt}</referenceAltitude>
+
+            <drift>${gps_drift}</drift> <!-- m -->
+            <velocityDrift>${gps_vel_drift}</velocityDrift> <!-- m/s-->
             <!-- TODO: add Gaussian noise based off Garmin GPS -->
         </plugin>
     </gazebo>
@@ -101,16 +101,16 @@
         <gravity>true</gravity>
         <sensor name="imu_sensor" type="imu">
             <always_on>true</always_on>
-            <update_rate>128.0</update_rate>
+            <update_rate>${imu_update_rate}</update_rate>
             <topic>__default_topic__</topic>
-            <!-- TODO: set Drift based off Phidget IMU -->
+            <!-- TODO: add Drift based on Phidget IMU -->
 
             <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
-                <topicName>${robotNamespace}/imu/data</topicName>
-                <bodyName>${tf_prefix}/imu_link</bodyName>
-                <frameName>${tf_prefix}/imu_link</frameName>
-                <updateRateHZ>128.0</updateRateHZ>
-                <gaussianNoise>0.0</gaussianNoise>  <!-- TODO: set Gaussian noise based off Phidget IMU -->
+                <topicName>${robotNamespace}/${imu_topic}</topicName>
+                <bodyName>${tf_prefix}/${imu_frame}</bodyName>
+                <frameName>${tf_prefix}/${imu_frame}</frameName>
+                <updateRateHZ>${imu_update_rate}</updateRateHZ>
+                <gaussianNoise>0.0</gaussianNoise>  <!-- TODO: set Gaussian noise based on Phidget IMU -->
                 <xyzOffset>0 0 0</xyzOffset>
                 <rpyOffset>0 0 0</rpyOffset>
                 <initialOrientationAsReference>false</initialOrientationAsReference>

--- a/robot/description/urdf/caffeine.gazebo.xacro
+++ b/robot/description/urdf/caffeine.gazebo.xacro
@@ -103,13 +103,14 @@
             <always_on>true</always_on>
             <update_rate>128.0</update_rate>
             <topic>__default_topic__</topic>
+            <!-- TODO: set Drift based off Phidget IMU -->
 
             <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
                 <topicName>${robotNamespace}/imu/data</topicName>
                 <bodyName>${tf_prefix}/imu_link</bodyName>
                 <frameName>${tf_prefix}/imu_link</frameName>
                 <updateRateHZ>128.0</updateRateHZ>
-                <gaussianNoise>0.0</gaussianNoise>
+                <gaussianNoise>0.0</gaussianNoise>  <!-- TODO: set Gaussian noise based off Phidget IMU -->
                 <xyzOffset>0 0 0</xyzOffset>
                 <rpyOffset>0 0 0</rpyOffset>
                 <initialOrientationAsReference>false</initialOrientationAsReference>

--- a/robot/description/urdf/caffeine.gazebo.xacro
+++ b/robot/description/urdf/caffeine.gazebo.xacro
@@ -93,5 +93,30 @@
             <!-- TODO: add Gaussian noise based off Garmin GPS -->
         </plugin>
     </gazebo>
+
+    <!-- IMU -->
+    <gazebo reference="${tf_prefix}/imu_link">
+        <material>Gazebo/Black</material>
+
+        <gravity>true</gravity>
+        <sensor name="imu_sensor" type="imu">
+            <always_on>true</always_on>
+            <update_rate>128.0</update_rate>
+            <topic>__default_topic__</topic>
+
+            <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
+                <topicName>${robotNamespace}/imu/data</topicName>
+                <bodyName>${tf_prefix}/imu_link</bodyName>
+                <frameName>${tf_prefix}/imu_link</frameName>
+                <updateRateHZ>128.0</updateRateHZ>
+                <gaussianNoise>0.0</gaussianNoise>
+                <xyzOffset>0 0 0</xyzOffset>
+                <rpyOffset>0 0 0</rpyOffset>
+                <initialOrientationAsReference>false</initialOrientationAsReference>
+            </plugin>
+            
+            <pose>0 0 0 0 0 0</pose>
+        </sensor>
+    </gazebo>
 </robot>
 

--- a/robot/description/urdf/caffeine.urdf.xacro
+++ b/robot/description/urdf/caffeine.urdf.xacro
@@ -13,7 +13,7 @@
     <joint name="${tf_prefix}/chassis_link_joint" type="fixed">
         <parent link="${tf_prefix}/base_link"/>
         <child link="${tf_prefix}/chassis_link"/>
-        <origin rpy="0 0 0" xyz="0 0 ${chassis_to_base_link_dist}"/>
+        <origin xyz="0 0 ${chassis_to_base_link_dist}" rpy="0 0 0"/>
     </joint>
 
     <!-- stand_link: origin for anything on the stand; located in the middle, on the top of the stand plate -->
@@ -21,7 +21,7 @@
     <joint name="${tf_prefix}/stand_link_joint" type="fixed">
         <parent link="${tf_prefix}/chassis_link"/>
         <child link="${tf_prefix}/stand_link"/>
-        <origin rpy="0 0 0" xyz="0 0 ${chassis_to_stand_link_dist}"/>
+        <origin xyz="0 0 ${chassis_to_stand_link_dist}" rpy="0 0 0" />
     </joint>
 
     <!-- wheels: associated to wheels that can be moved by a motor -->

--- a/robot/description/urdf/constants.xacro
+++ b/robot/description/urdf/constants.xacro
@@ -11,7 +11,7 @@
 
     <!-- Chassis --> 
     <xacro:property name="chassis_to_base_link_dist" value="0.501747"/>
-    <xacro:property name="chassis_to_stand_link_dist" value="0.713459"/>
+    <xacro:property name="chassis_to_stand_link_dist" value="0.698253"/>
 
     <xacro:property name="chassis_link_mass" value="33.9"/>
 
@@ -95,5 +95,11 @@
     <xacro:property name="gps_diam" value="0.061"/>
     <xacro:property name="gps_length" value="0.0195"/>
     <xacro:property name="gps_mass" value="0.165"/>
+
+    <!-- Phidget IMU -->
+   <xacro:property name="phidget_length" value="0.04"/>
+   <xacro:property name="phidget_width" value="0.0375"/>
+   <xacro:property name="phidget_height" value="0.01"/>
+   <xacro:property name="phidget_mass" value="0.04"/>
 </robot>
 

--- a/robot/description/urdf/constants.xacro
+++ b/robot/description/urdf/constants.xacro
@@ -96,10 +96,27 @@
     <xacro:property name="gps_length" value="0.0195"/>
     <xacro:property name="gps_mass" value="0.165"/>
 
+    <xacro:property name="gps_frame" value="gps_link"/>
+    <xacro:property name="gps_topic" value="gps/fix"/>
+    <xacro:property name="gps_vel_topic" value="gps/fix_velocity"/>
+    <xacro:property name="gps_update_rate" value="5.0"/>
+
+    <!-- NOTE: GPS coordinates for UofT St. George Campus -->
+    <xacro:property name="ref_lat" value="43.6570"/>
+    <xacro:property name="ref_lon" value="-79.3903"/>
+    <xacro:property name="ref_alt" value="76.0000"/>
+
+    <xacro:property name="gps_drift" value="1.5 1.5 1.5"/>
+    <xacro:property name="gps_vel_drift" value="0.05 0.05 0.05"/>
+
     <!-- Phidget IMU -->
    <xacro:property name="phidget_length" value="0.04"/>
    <xacro:property name="phidget_width" value="0.0375"/>
    <xacro:property name="phidget_height" value="0.01"/>
    <xacro:property name="phidget_mass" value="0.04"/>
+
+   <xacro:property name="imu_frame" value="imu_link"/>
+   <xacro:property name="imu_topic" value="imu/data"/>
+   <xacro:property name="imu_update_rate" value="128.0"/>
 </robot>
 

--- a/robot/description/urdf/stand_link.urdf.xacro
+++ b/robot/description/urdf/stand_link.urdf.xacro
@@ -31,10 +31,39 @@
         </collision>
     </link>
 
-    <!-- GPS: attach gps_link to base_link -->
+    <!-- GPS: attach gps_link to stand_link -->
     <joint name="${tf_prefix}/gps_joint" type="fixed">
         <parent link="${tf_prefix}/stand_link"/>
         <child link="${tf_prefix}/gps_link"/>
+        <origin xyz="0 0 ${(gps_length + phidget_height) / 2.0}" rpy="0 0 0"/>
+    </joint>
+
+    <!-- IMU -->
+    <link name="${tf_prefix}/imu_link">
+        <inertial>
+            <mass value="${phidget_mass}"/>
+            <xacro:box_inertia mass="${phidget_mass}" length="${phidget_length}" width="${phidget_width}" height="${phidget_height}"/>
+        </inertial>
+
+        <visual>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+            <box size="${phidget_length} ${phidget_width} ${phidget_height}"/>
+            </geometry>
+        </visual>
+
+        <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+            <box size="${phidget_length} ${phidget_width} ${phidget_height}"/>
+            </geometry>
+        </collision>
+    </link>
+
+    <!-- IMU: attach imu_link to stand_link -->
+    <joint name="${tf_prefix}/base_link_to_imu_link" type="fixed">
+        <parent link="${tf_prefix}/stand_link"/>
+        <child link="${tf_prefix}/imu_link"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
     </joint>
 


### PR DESCRIPTION
IMU is placed on the stand. It is placed in the center, with the GPS on top of it. IMU data is published on the topic `caffeine/imu/data` using the `caffeine/imu_link` frame.

I also fixed the origin of the `stand_link`, as it was a bit too high.

After playing around with the GPS and IMU, I have the following information that would be important when dealing with the `navsat_transform`:
- *North* aligns with the `x` gazebo world axis
- yaw positive is in the CCW direction
- yaw is 0 when Caffeine faces the `x` direction (ie. *North*)
- Down is positive for the IMU (z = + 1g when placed flat)