### PR TITLE
Caff 10 - Fuse Local and GPS Odometry

### DIFF
--- a/odom/odom/config/global.yaml
+++ b/odom/odom/config/global.yaml
@@ -8,7 +8,7 @@ odom_frame: caffeine/odom
 base_link_frame: caffeine/base_link
 world_frame: map
 
-# publish transform: world_frame --> base_link_frame
+# publish transform: map_frame --> odom_frame
 publish_tf: true
 
 transform_time_offset: 0.05

--- a/odom/odom/config/global.yaml
+++ b/odom/odom/config/global.yaml
@@ -3,10 +3,10 @@ frequency: 50
 # Specify planar environment
 two_d_mode: true
 
-map_frame: map
+map_frame: caffeine/map
 odom_frame: caffeine/odom
 base_link_frame: caffeine/base_link
-world_frame: map
+world_frame: caffeine/map
 
 # publish transform: map_frame --> odom_frame
 publish_tf: true

--- a/odom/odom/config/global.yaml
+++ b/odom/odom/config/global.yaml
@@ -1,0 +1,52 @@
+frequency: 50
+
+# Specify planar environment
+two_d_mode: true
+
+map_frame: map
+odom_frame: caffeine/odom
+base_link_frame: caffeine/odom
+world_frame: map
+
+# publish transform: world_frame --> base_link_frame
+publish_tf: true
+
+transform_time_offset: 0.05
+
+# See /diagnostics topic for debug
+print_diagnostics: true
+
+## Odometry Sensor(s) ##
+
+odom0: caffeine/odom
+odom0_config: [true,  true,  false,
+               false, false, false,
+               true , true , false,
+               false, false, true ,
+               false, false, false]
+odom0_queue_size: 10
+odom0_differential: false 
+odom0_relative: false
+
+odom1: zed/zed_node/odom
+odom1_config: [false, false, false,
+               false, false, false,
+               true , true , false,
+               false, false, true,
+               false, false, false]
+odom1_queue_size: 10
+odom1_differential: true
+odom1_relative: false
+
+## IMU Sensor(s) ## 
+
+imu0: caffeine/imu/data 
+imu0_config: [false, false, false, 
+              false, false, true ,
+              false, false, false,
+              false, false, true , 
+              true , true , false]
+imu0_queue_size: 10
+imu0_differential: false
+imu0_relative: true
+imu0_remove_gravitational_acceleration: true

--- a/odom/odom/config/global.yaml
+++ b/odom/odom/config/global.yaml
@@ -5,7 +5,7 @@ two_d_mode: true
 
 map_frame: map
 odom_frame: caffeine/odom
-base_link_frame: caffeine/odom
+base_link_frame: caffeine/base_link
 world_frame: map
 
 # publish transform: world_frame --> base_link_frame

--- a/odom/odom/config/odom_global.yaml
+++ b/odom/odom/config/odom_global.yaml
@@ -14,7 +14,7 @@ publish_tf: true
 transform_time_offset: 0.05
 
 # See /diagnostics topic for debug
-print_diagnostics: true
+print_diagnostics: false
 
 ## Odometry Sensor(s) ##
 

--- a/odom/odom/config/odom_global.yaml
+++ b/odom/odom/config/odom_global.yaml
@@ -3,12 +3,12 @@ frequency: 50
 # Specify planar environment
 two_d_mode: true
 
-map_frame: map
+map_frame: caffeine/map
 odom_frame: caffeine/odom
 base_link_frame: caffeine/base_link
-world_frame: caffeine/odom
+world_frame: caffeine/map
 
-# publish transform: world_frame --> base_link_frame
+# publish transform: world_frame --> odom_frame
 publish_tf: true
 
 transform_time_offset: 0.05

--- a/odom/odom/config/odom_global.yaml
+++ b/odom/odom/config/odom_global.yaml
@@ -18,7 +18,7 @@ print_diagnostics: true
 
 ## Odometry Sensor(s) ##
 
-odom0: caffeine/odom
+odom0: caffeine/odometry/gps
 odom0_config: [true,  true,  false,
                false, false, false,
                true , true , false,
@@ -28,7 +28,7 @@ odom0_queue_size: 10
 odom0_differential: false 
 odom0_relative: false
 
-odom1: zed/zed_node/odom
+odom1: caffeine/odometry/local
 odom1_config: [false, false, false,
                false, false, false,
                true , true , false,
@@ -48,5 +48,5 @@ imu0_config: [false, false, false,
               true , true , false]
 imu0_queue_size: 10
 imu0_differential: false
-imu0_relative: true
+imu0_relative: false
 imu0_remove_gravitational_acceleration: true

--- a/odom/odom/config/odom_local.yaml
+++ b/odom/odom/config/odom_local.yaml
@@ -6,9 +6,9 @@ two_d_mode: true
 map_frame: caffeine/map
 odom_frame: caffeine/odom
 base_link_frame: caffeine/base_link
-world_frame: caffeine/map
+world_frame: caffeine/odom
 
-# publish transform: map_frame --> odom_frame
+# publish transform: world_frame --> base_link_frame
 publish_tf: true
 
 transform_time_offset: 0.05

--- a/odom/odom/config/odom_local.yaml
+++ b/odom/odom/config/odom_local.yaml
@@ -14,7 +14,7 @@ publish_tf: true
 transform_time_offset: 0.05
 
 # See /diagnostics topic for debug
-print_diagnostics: true
+print_diagnostics: false
 
 ## Odometry Sensor(s) ##
 

--- a/odom/odom/launch/odom.launch
+++ b/odom/odom/launch/odom.launch
@@ -2,10 +2,17 @@
    <arg name="robot" default="caffeine"/>
 
     <!-- Compute local odometry: publish odom frame -->
-    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization" clear_params="true" output="screen">
+    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_local" clear_params="true" output="screen">
         <remap from="odometry/filtered" to="$(arg robot)/odometry/local"/>
         
         <rosparam command="load" file="$(find odom)/config/localization.yaml"/>
+    </node>
+
+    <!-- Compute local odometry: publish odom frame -->
+    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_global" clear_params="true" output="screen">
+        <remap from="odometry/filtered" to="$(arg robot)/odometry/global"/>
+
+        <rosparam command="load" file="$(find odom)/config/global.yaml"/>
     </node>
 
     <!-- Establish transform b/w Earth reference and Robot reference -->
@@ -16,4 +23,5 @@
     </node>
 
 </launch>
+
 

--- a/odom/odom/launch/odom.launch
+++ b/odom/odom/launch/odom.launch
@@ -13,12 +13,14 @@
         <remap from="odometry/filtered" to="$(arg robot)/odometry/global"/>
 
         <rosparam command="load" file="$(find odom)/config/global.yaml"/>
+        <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
     </node>
 
     <!-- Establish transform b/w Earth reference and Robot reference -->
     <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" respawn="true" ns="$(arg robot)">
         <remap from="odometry/filtered" to="odom"/>
 
+        <rosparam command="load" file="$(find odom)/config/global.yaml"/>
         <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
     </node>
 

--- a/odom/odom/launch/odom.launch
+++ b/odom/odom/launch/odom.launch
@@ -17,7 +17,7 @@
 
     <!-- Establish transform b/w Earth reference and Robot reference -->
     <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" respawn="true" ns="$(arg robot)">
-        <remap from="odometry/filtered" to="odom"/>
+        <remap from="odometry/filtered" to="odometry/global"/>
 
         <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
     </node>

--- a/odom/odom/launch/odom.launch
+++ b/odom/odom/launch/odom.launch
@@ -5,22 +5,20 @@
     <node pkg="robot_localization" type="ekf_localization_node" name="ekf_local" clear_params="true" output="screen">
         <remap from="odometry/filtered" to="$(arg robot)/odometry/local"/>
         
-        <rosparam command="load" file="$(find odom)/config/localization.yaml"/>
+        <rosparam command="load" file="$(find odom)/config/odom_local.yaml"/>
     </node>
 
-    <!-- Compute local odometry: publish odom frame -->
+    <!-- Compute global odometry: publish map frame -->
     <node pkg="robot_localization" type="ekf_localization_node" name="ekf_global" clear_params="true" output="screen">
         <remap from="odometry/filtered" to="$(arg robot)/odometry/global"/>
 
-        <rosparam command="load" file="$(find odom)/config/global.yaml"/>
-        <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
+        <rosparam command="load" file="$(find odom)/config/odom_global.yaml"/>
     </node>
 
     <!-- Establish transform b/w Earth reference and Robot reference -->
     <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" respawn="true" ns="$(arg robot)">
         <remap from="odometry/filtered" to="odom"/>
 
-        <rosparam command="load" file="$(find odom)/config/global.yaml"/>
         <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
     </node>
 

--- a/robot/description/rviz/caffeine.rviz
+++ b/robot/description/rviz/caffeine.rviz
@@ -5,7 +5,6 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /TF1
         - /Sensors1
         - /Sensors1/Odometry1
         - /Navigation1
@@ -52,7 +51,7 @@ Visualization Manager:
         Y: 0
         Z: 0
       Plane: XY
-      Plane Cell Count: 10
+      Plane Cell Count: 50
       Reference Frame: <Fixed Frame>
       Value: true
     - Alpha: 1
@@ -325,7 +324,7 @@ Visualization Manager:
                 Shaft Length: 1
                 Shaft Radius: 0.05000000074505806
                 Value: Arrow
-              Topic: ""
+              Topic: /caffeine/odometry/global
               Unreliable: false
               Value: false
             - Angle Tolerance: 0.10000000149011612

--- a/robot/description/rviz/caffeine.rviz
+++ b/robot/description/rviz/caffeine.rviz
@@ -5,6 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
+        - /TF1
         - /Sensors1
         - /Sensors1/Odometry1
         - /Sensors1/Camera1
@@ -154,6 +155,8 @@ Visualization Manager:
           Value: false
         caffeine/left_wheel_link:
           Value: false
+        caffeine/map:
+          Value: true
         caffeine/odom:
           Value: true
         caffeine/right_wheel_link:
@@ -165,36 +168,37 @@ Visualization Manager:
         caffeine/zed_camera_link_optical:
           Value: false
         utm:
-          Value: true
+          Value: false
       Marker Scale: 1
       Name: TF
       Show Arrows: true
       Show Axes: true
       Show Names: true
       Tree:
-        caffeine/odom:
-          caffeine/base_link:
-            caffeine/base_laser:
-              {}
-            caffeine/chassis_link:
-              caffeine/back_caster_link:
+        caffeine/map:
+          caffeine/odom:
+            caffeine/base_link:
+              caffeine/base_laser:
                 {}
-              caffeine/front_caster_link:
-                {}
-              caffeine/left_wheel_link:
-                {}
-              caffeine/right_wheel_link:
-                {}
-              caffeine/stand_link:
-                caffeine/gps_link:
+              caffeine/chassis_link:
+                caffeine/back_caster_link:
                   {}
-                caffeine/imu_link:
+                caffeine/front_caster_link:
                   {}
-                caffeine/zed_camera_link:
-                  caffeine/camera_link:
+                caffeine/left_wheel_link:
+                  {}
+                caffeine/right_wheel_link:
+                  {}
+                caffeine/stand_link:
+                  caffeine/gps_link:
                     {}
-                  caffeine/zed_camera_link_optical:
+                  caffeine/imu_link:
                     {}
+                  caffeine/zed_camera_link:
+                    caffeine/camera_link:
+                      {}
+                    caffeine/zed_camera_link_optical:
+                      {}
           utm:
             {}
       Update Interval: 0
@@ -290,6 +294,40 @@ Visualization Manager:
               Topic: /caffeine/odometry/local
               Unreliable: false
               Value: true
+            - Angle Tolerance: 0.10000000149011612
+              Class: rviz/Odometry
+              Covariance:
+                Orientation:
+                  Alpha: 0.5
+                  Color: 255; 255; 127
+                  Color Style: Unique
+                  Frame: Local
+                  Offset: 1
+                  Scale: 1
+                  Value: true
+                Position:
+                  Alpha: 0.30000001192092896
+                  Color: 204; 51; 204
+                  Scale: 1
+                  Value: true
+                Value: true
+              Enabled: false
+              Keep: 1
+              Name: Global Odometry
+              Position Tolerance: 0.10000000149011612
+              Shape:
+                Alpha: 1
+                Axes Length: 1
+                Axes Radius: 0.10000000149011612
+                Color: 138; 226; 52
+                Head Length: 0.30000001192092896
+                Head Radius: 0.10000000149011612
+                Shaft Length: 1
+                Shaft Radius: 0.05000000074505806
+                Value: Arrow
+              Topic: ""
+              Unreliable: false
+              Value: false
             - Angle Tolerance: 0.10000000149011612
               Class: rviz/Odometry
               Covariance:
@@ -430,6 +468,7 @@ Visualization Manager:
                   Odometry:
                     Encoders: true
                     GPS Odometry: true
+                    Global Odometry: true
                     Local Odometry: true
                     Value: true
                     Visual Odometry: true
@@ -629,7 +668,7 @@ Visualization Manager:
   Global Options:
     Background Color: 48; 48; 48
     Default Light: true
-    Fixed Frame: caffeine/odom
+    Fixed Frame: caffeine/map
     Frame Rate: 15
   Name: root
   Tools:
@@ -652,26 +691,21 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rtabmap_ros/OrbitOriented
-      Distance: 5.5
+      Angle: 0
+      Class: rviz/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Focal Point:
-        X: 0.176552414894104
-        Y: 0.021892040967941284
-        Z: 0.5596098303794861
-      Focal Shape Fixed Size: true
-      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.27479758858680725
+      Scale: 100
       Target Frame: <Fixed Frame>
-      Value: OrbitOriented (rtabmap_ros)
-      Yaw: 2.642225980758667
+      Value: TopDownOrtho (rviz)
+      X: 0
+      Y: 0
     Saved: ~
 Window Geometry:
   Camera:


### PR DESCRIPTION
As the PR suggests, local odom (computed by `ekf_local`)  has been fused with GPS odom (computed by `navsat`) and the imu (published on `imu/data`) by the `ekf_global` (another instance of ekf_localization_node) node to publish the map frame and `odometry/global` topic.

Tested in RViz and everything seems to behave as expected. You will notice RViz now displays everything using the new fixed frame: map. Likewise RViz now defaults to a top down orthographic view.

As a general rule of thumb, if you plan on navigating (ie. creating and executing local navigation plans), it is best to use `odometry/local` bc it is guaranteed to be continuous. If you need global accurate odom but can handle discrete jumps in the values, then use `odometry/global`.

For those curious of how all this odometry stuff works, on a high level we are doing the following:
1) Fuse encoders odom + visual odom + imu 
--(ekf_local)--> 
`odometry/local` + publish **odom frame**
2) Use GPS + initial reading of odom, imu 
--(navsat)--> 
`odometry/gps` + publish **utm frame**
3) Fuse local odom + GPS odom (absolute position) + imu (absolute orientation) 
--(ekf_global)--> 
`odometry/global` + publish **map frame**