### PR TITLE
CAFF-85 - Changed Default World to pavement

### DIFF
--- a/description/launch/simulate.launch
+++ b/description/launch/simulate.launch
@@ -7,7 +7,7 @@
     <!-- IGVC worlds: full, walls, ramp, plain -->
     <!-- IGVC world types: pavement (2022 IGVC), grass (<2021 IGVC)-->
     <arg name="world" default="full"/>
-    <arg name="world_type" default="grass"/>
+    <arg name="world_type" default="pavement"/>
 
     <!-- Simulate 'world' in Gazebo -->
     <include file="$(find gazebo_ros)/launch/empty_world.launch">


### PR DESCRIPTION
Updated default world 

Test:
- `roslaunch description simulate.launch`
- Observed new World
- Switched to old world via terminal: `roslaunch description simulate.launch world_type:=grass`
- Enable the gui in both cases

closes #85