### PR TITLE
Caff 100 - Launch ignore lidar node on startup

### DIFF
--- a/nav/filter_lidar_data/include/ignore_lidar_node.h
+++ b/nav/filter_lidar_data/include/ignore_lidar_node.h
@@ -25,8 +25,8 @@ class IgnoreLidarNode
             double y;
         };
         
-        GpsCoord second_waypoint_ = {43.6571667, -79.3903788}; //Temporarily set to in SIM Gps coordinates. CHANGE HERE LATER
-        GpsCoord third_waypoint_ = {43.6571678, -79.3902588};
+        GpsCoord second_waypoint_;
+        GpsCoord third_waypoint_;
 
         std::array<OdomCoord, 2> bounds_;
 

--- a/nav/filter_lidar_data/include/ignore_lidar_node.h
+++ b/nav/filter_lidar_data/include/ignore_lidar_node.h
@@ -15,6 +15,8 @@ class IgnoreLidarNode
         ros::NodeHandle nh_;
         ros::Publisher ignore_lidar_pub_;
 
+        bool debug = false;
+
         struct GpsCoord {
             double latitude{};
             double longitude{};

--- a/nav/filter_lidar_data/launch/filter_lidar_data.launch
+++ b/nav/filter_lidar_data/launch/filter_lidar_data.launch
@@ -1,4 +1,13 @@
 <launch>
-    <node name="filter_lidar_data" pkg="filter_lidar_data" type="ignore_lidar_node" output="screen">
+    <node 
+        name="filter_lidar_data" 
+        pkg="filter_lidar_data" 
+        type="ignore_lidar_node" 
+        output="screen"
+    >
+        <param name="second_waypoint_latitude" value="43.6571667"/>
+        <param name="second_waypoint_longitude" value="-79.3903788"/>
+        <param name="third_waypoint_latitude" value="43.6571678"/>
+        <param name="third_waypoint_longitude" value="-79.3902588"/>
     </node>
 </launch>

--- a/nav/filter_lidar_data/src/ignore_lidar_node.cpp
+++ b/nav/filter_lidar_data/src/ignore_lidar_node.cpp
@@ -12,6 +12,14 @@ IgnoreLidarNode::IgnoreLidarNode(ros::NodeHandle nh)
 {
     ROS_INFO("Connected to Node");
 
+    // Obtain waypoint gps coordingates from launch file
+    nh_.getParam("second_waypoint_latitude", second_waypoint_.latitude);
+    nh_.getParam("second_waypoint_longitude", second_waypoint_.longitude);
+    ROS_INFO("Second Waypoint Coordinates: %f, %f", second_waypoint_.latitude, second_waypoint_.longitude);
+    nh_.getParam("third_waypoint_latitude", third_waypoint_.latitude);
+    nh_.getParam("third_waypoint_longitude", third_waypoint_.longitude);
+    ROS_INFO("Third Waypoint Coordinates: %f, %f", third_waypoint_.latitude, third_waypoint_.longitude);
+
     // Transform Gps waypoints into pose
     geometry_msgs::PoseStamped second_pose_stamped = getPoseFromGps(second_waypoint_.latitude, 
                                                             second_waypoint_.longitude, "/odom");

--- a/nav/filter_lidar_data/src/ignore_lidar_node.cpp
+++ b/nav/filter_lidar_data/src/ignore_lidar_node.cpp
@@ -56,8 +56,11 @@ void IgnoreLidarNode::lidarCallback(const sensor_msgs::LaserScanConstPtr& lidar_
         cur_odom_.x >= bounds_[1].x && 
         cur_odom_.y <= bounds_[0].y && 
         cur_odom_.y >= bounds_[1].y) {
-
-        ROS_INFO("At Second Waypoint");
+        
+        if (debug) {
+            ROS_INFO("At Second Waypoint. Currently at: x:%f, y:%f", cur_odom_.x, cur_odom_.y);
+        }
+        
         sensor_msgs::LaserScan output_msg = *lidar_msg; // Make a copy of lidar_msg
 
         // Set each element in ranges to inf (No obstacles present) to clear costmap
@@ -69,7 +72,11 @@ void IgnoreLidarNode::lidarCallback(const sensor_msgs::LaserScanConstPtr& lidar_
         ignore_lidar_pub_.publish(output_msg);
 
     } else {
-        ROS_INFO("NOT at Second Waypoint");
+        
+        if (debug) {
+            ROS_INFO("NOT at Second Waypoint. Currently at: x:%f, y:%f", cur_odom_.x, cur_odom_.y);
+        }
+        
         ignore_lidar_pub_.publish(lidar_msg); // Republish the same msg. No changes to data.
     }
 }

--- a/nav/nav_stack/launch/move_base.launch
+++ b/nav/nav_stack/launch/move_base.launch
@@ -19,17 +19,8 @@
         <param name="base_global_planner" value="navfn/NavfnROS"/>
     </node>
 
-    <!-- Alternative to launch
-    <node name="filter_lidar_data" pkg="filter_lidar_data" type="ignore_lidar_node" output="screen">
-        <param name="second_waypoint_latitude" value="43.6571667"/>
-        <param name="second_waypoint_longitude" value="-79.3903788"/>
-        <param name="third_waypoint_latitude" value="43.6571678"/>
-        <param name="third_waypoint_longitude" value="-79.3902588"/>
-    </node>
-    --> 
-
     <!-- Launch filtered lidar data topic used for costmap-->
-    <include file="$(find filter_lidar_data)/launch/filter_lidar_data.launch"> </include>
+    <include file="$(find filter_lidar_data)/launch/filter_lidar_data.launch"/>
 
     <!-- TODO: always have a manual override available when doing autonomous navigation -->
 

--- a/nav/nav_stack/launch/move_base.launch
+++ b/nav/nav_stack/launch/move_base.launch
@@ -19,6 +19,17 @@
         <param name="base_global_planner" value="navfn/NavfnROS"/>
     </node>
 
+    <!-- Alternative to launch
+    <node name="filter_lidar_data" pkg="filter_lidar_data" type="ignore_lidar_node" output="screen">
+        <param name="second_waypoint_latitude" value="43.6571667"/>
+        <param name="second_waypoint_longitude" value="-79.3903788"/>
+        <param name="third_waypoint_latitude" value="43.6571678"/>
+        <param name="third_waypoint_longitude" value="-79.3902588"/>
+    </node>
+    --> 
+
+    <!-- Launch filtered lidar data topic used for costmap-->
+    <include file="$(find filter_lidar_data)/launch/filter_lidar_data.launch"> </include>
 
     <!-- TODO: always have a manual override available when doing autonomous navigation -->
 


### PR DESCRIPTION
Closes #100. Added the filter_lidar_data.launch as an include in move_base.launch so that it will be launched simultaneously. Also added a debug toggle to print extra messages if desired. 