### PR TITLE
fix rtabmap launching issue

### DIFF
--- a/description/launch/zed_emulation.launch
+++ b/description/launch/zed_emulation.launch
@@ -13,13 +13,13 @@
         </node>
 
         <!-- Disparity to depth -->
-        <node pkg="nodelet" type="nodelet" name="disparity2depth" args="standalone rtabmap_ros/disparity_to_depth">
+        <node pkg="nodelet" type="nodelet" name="disparity2depth" args="standalone rtabmap_util/disparity_to_depth">
             <remap from="depth"                 to="depth/depth_registered"/>
             <remap from="disparity"             to="disparity/disparity_registered"/>
         </node>
 
         <!-- Visual Odometry using rtabmap_ros's stereo_odometry wrapper -->
-        <node pkg="rtabmap_ros" type="stereo_odometry" name="stereo_odometry">
+        <node pkg="rtabmap_odom" type="stereo_odometry" name="stereo_odometry">
             <remap from="left/image_rect"       to="left/image_rect_color"/>
             <remap from="left/camera_info"      to="left/camera_info"/>
 


### PR DESCRIPTION
- Fixes rtabmap launching issue caused due to packages renaming

**Warning**: this will break old versions of rtabmap. Therefore make sure you update rtab to the latest version

To test, I simply ran:
```
roslaunch description simulate.launch
```

And make sure that there was no errors 