### PR TITLE
CAFF-147: Added Package and Launch Files to Run New Lidar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cv/zed-ros-wrapper"]
 	path = cv/zed-ros-wrapper
 	url = https://github.com/stereolabs/zed-ros-wrapper.git
+[submodule "sensors/rplidar_ros"]
+	path = sensors/rplidar_ros
+	url = https://github.com/Slamtec/rplidar_ros.git

--- a/sensors/sensors/launch/rplidar_test.launch
+++ b/sensors/sensors/launch/rplidar_test.launch
@@ -1,0 +1,12 @@
+<launch>
+    <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" output="screen">
+        <remap from="scan" to="scan_upper"/>
+    <param name="serial_port"         type="string" value="/dev/ttyUSB0"/>
+    <param name="serial_baudrate"     type="int"    value="115200"/><!--A1/A2 -->
+    <param name="frame_id"            type="string" value="laser"/>
+    <param name="inverted"            type="bool"   value="false"/>
+    <param name="angle_compensate"    type="bool"   value="true"/>
+    </node>
+
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rplidar_ros)/rviz/rplidar.rviz" />
+</launch>

--- a/sensors/sensors/launch/sensors.launch
+++ b/sensors/sensors/launch/sensors.launch
@@ -5,4 +5,5 @@
     <include file="$(find nmea_navsat_driver)/launch/nmea_serial_driver.launch">
         <arg name="launch_state" value="$(arg launch_state)"/>
     </include>
+    <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
 </launch>

--- a/sensors/sensors/launch/sensors.launch
+++ b/sensors/sensors/launch/sensors.launch
@@ -5,5 +5,14 @@
     <include file="$(find nmea_navsat_driver)/launch/nmea_serial_driver.launch">
         <arg name="launch_state" value="$(arg launch_state)"/>
     </include>
-    <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
+    
+    <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" output="screen">
+        <remap from="scan" to="scan_upper"/>
+    <param name="serial_port"         type="string" value="/dev/ttyUSB0"/>
+    <param name="serial_baudrate"     type="int"    value="115200"/><!--A1/A2 -->
+    <param name="frame_id"            type="string" value="laser"/>
+    <param name="inverted"            type="bool"   value="false"/>
+    <param name="angle_compensate"    type="bool"   value="true"/>
+    </node>
+
 </launch>

--- a/sensors/sensors/launch/sensors.launch
+++ b/sensors/sensors/launch/sensors.launch
@@ -5,5 +5,5 @@
     <include file="$(find nmea_navsat_driver)/launch/nmea_serial_driver.launch">
         <arg name="launch_state" value="$(arg launch_state)"/>
     </include>
-    <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
+    <include file="$(find rplidar_ros)/launch/test_rplidar.launch"/>
 </launch>

--- a/sensors/sensors/launch/sensors.launch
+++ b/sensors/sensors/launch/sensors.launch
@@ -5,5 +5,5 @@
     <include file="$(find nmea_navsat_driver)/launch/nmea_serial_driver.launch">
         <arg name="launch_state" value="$(arg launch_state)"/>
     </include>
-    <include file="$(find rplidar_ros)/launch/test_rplidar.launch"/>
+    <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
 </launch>


### PR DESCRIPTION
**Sensor updates:**

- Added rplidar_ros as submodule to this repository. rplidar_ros contains the package to run the new lidar.
- Added code to sensors.launch to launch the new lidar and remap its topic from /scan to /scan_upper.
- Added test launch script (rplidar_test.launch) to independently test new lidar.

**Notes:**

The computer that will have a usb connection to the new lidar must have the port configured using udev rules.
Instructions:

1. Navigate to /etc/udev/rules.d
2. Create a file called 80-local.rules (if there is not one there already). 80-local.rules needs the following line in it to automatically configure the USB port for the new lidar whenever it is plugged in:

 KERNEL=="ttyUSB*", MODE="0666"

sudo access is needed for creating/modifying 80-local.rules. (I used vim to do this.)

The lidar needs to be mounted such that the x axis in this diagram points to the front of Caffeine.

![image](https://github.com/UTRA-ART/Caffeine/assets/69325418/f46f0e6f-7f5e-4b07-83fb-6c8333169036)

Example output from new lidar:

![image](https://github.com/UTRA-ART/Caffeine/assets/69325418/0b2f49c1-18ab-4321-99af-9da3ebad0e06)
