### PR TITLE
This makes ramp detection with the actual lidar sensors on the robot

### DIFF
--- a/nav/filter_lidar_data/launch/filter_lidar_data.launch
+++ b/nav/filter_lidar_data/launch/filter_lidar_data.launch
@@ -25,7 +25,7 @@
     >
          <!-- Unless this can track a constant defined in constants.xacro, make sure this is updated to be actual distance b/w lidars -->
         <param name="distance_to_second_lidar" value="0.14"/>
-        <param name="max_theta_degrees" value="9" />
+        <param name="max_theta_degrees" value="45" />
         <param name="main_topic" value="/scan" />
         <param name="upper_topic" value="/scan_upper" />
         <param name="out_topic" value="/scan_modified" />
@@ -43,12 +43,8 @@
         <!-- Angular range total in degrees, ie 360 degrees if all angles  (not referring to start stop range above, but total of the upper lidar array) -->
         <param name="upper_lidar_angular_total_range" value='270' if="$(eval launch_state =='sim')" /> <!-- Use 270 for sim, and 360 for irl -->
         <param name="upper_lidar_angular_total_range" value="360" unless="$(eval launch_state =='sim')"/>
-
-
-        <!-- Total indices by lidar, unused since we have stop index above -->
-        <!-- <param name="upper_lidar_count" value="1080" /> -->
-
+        
         <!-- Main(lower) lidar angular range -->
-        <param name="main_lidar_angular_total_range" value='270' />
+        <param name="main_lidar_angular_total_range" value='180' />
     </node>
 </launch>

--- a/nav/filter_lidar_data/launch/filter_lidar_data.launch
+++ b/nav/filter_lidar_data/launch/filter_lidar_data.launch
@@ -39,13 +39,14 @@
         <param name="launch_state" value="$(arg launch_state)" />
         <!-- This will typically be upper lidar's total point ,count - 1, unless 0 is not your start index -->
         <param name="upper_lidar_stop_index" value="1080" if="$(eval launch_state =='sim')" />  <!-- Use 1080 for sim, and 1145 for irl -->
-        <param name="upper_lidar_stop_index" value="1145" unless="$(eval launch_state =='sim')"/>
+        <param name="upper_lidar_stop_index" value="1145" unless="$(eval launch_state =='sim')" />
         
         <!-- Angular range total in degrees, ie 360 degrees if all angles  (not referring to start stop range above, but total of the upper lidar array) -->
         <param name="upper_lidar_angular_total_range" value='270' if="$(eval launch_state =='sim')" /> <!-- Use 270 for sim, and 360 for irl -->
         <param name="upper_lidar_angular_total_range" value="360" unless="$(eval launch_state =='sim')"/>
         
         <!-- Main(lower) lidar angular range -->
-        <param name="main_lidar_angular_total_range" value='180' />
+        <param name="main_lidar_angular_total_range" value='270' if="$(eval launch_state =='sim')" />
+        <param name="main_lidar_angular_total_range" value='180' unless="$(eval launch_state =='sim')" />
     </node>
 </launch>

--- a/nav/filter_lidar_data/src/dual_lidar_filter_node.cpp
+++ b/nav/filter_lidar_data/src/dual_lidar_filter_node.cpp
@@ -3,10 +3,12 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <math.h>
 #include <functional>
 #include <limits>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 // const int LIDAR_BUF_LEN = 1080;
 
@@ -87,6 +89,7 @@ private:
     // modify main array with original lidar to contain filtered values, based on comparing with upper sensor
     void ramp_filter(std::vector<float>& out, const float main[]) {
         const float inf = std::numeric_limits<float>::infinity();
+        bool all_inf = true; // for carto fix below
         for (int i = 0; i < out.size(); i++) {
             const float comp_depth = last_upper_ranges[second_idx_fn(i, out.size())];
             float depth = comp_depth - main[i];
@@ -95,6 +98,12 @@ private:
             } else {
                 out[i] = main[i];
             }
+            if (!std::isinf(out[i])) {
+                all_inf = false;
+            }
+        }
+        if (all_inf) { // if all inf, carto seems to not like it!
+            std::fill(out.begin(), out.end(), NAN);
         }
     }
     void get_constants() {

--- a/sensors/sensors/launch/dual_lidar_test.launch
+++ b/sensors/sensors/launch/dual_lidar_test.launch
@@ -1,0 +1,20 @@
+<launch>
+    <arg name="launch_state" default="sim"/>
+    <include file="$(find urg_node)/launch/urg_lidar.launch"/>
+    <!-- <include file="$(find phidgets_imu)/launch/imu.launch"/>
+    <include file="$(find nmea_navsat_driver)/launch/nmea_serial_driver.launch">
+        <arg name="launch_state" value="$(arg launch_state)"/> -->
+    <!-- </include> -->
+    
+    <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" output="screen">
+        <remap from="scan" to="scan_upper"/>
+    <param name="serial_port"         type="string" value="/dev/ttyUSB0"/>
+    <param name="serial_baudrate"     type="int"    value="115200"/><!--A1/A2 -->
+    <param name="frame_id"            type="string" value="laser"/>
+    <param name="inverted"            type="bool"   value="false"/>
+    <param name="angle_compensate"    type="bool"   value="true"/>
+    </node>
+
+    <!-- <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rplidar_ros)/rviz/rplidar.rviz" /> -->
+
+</launch>


### PR DESCRIPTION
Changes:
Reading from lidar uses size of the vector coming in rather than a fixed expected buffer value. This is not the case for the upper lidar at the moment.