### PR TITLE
CAFF-150: Update scheduler.py and Update Wheel Separation After Modification at IGVC

### DIFF
--- a/description/launch/utm.launch
+++ b/description/launch/utm.launch
@@ -1,6 +1,6 @@
 <launch>
     <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" respawn="true">
-        <remap from="odometry/filtered" to="odometry/global"/>
+        <remap from="odometry/filtered" to="odometry/gps"/>
 
         <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
     </node>

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -213,19 +213,19 @@ class Scheduler:
         self.wait_for_condition('odom_gps_published', 25)
         rospy.loginfo('UTM initialized.')
 
-        # Run odom, wait for odom local, global
-        rospy.loginfo('Initializing odometry...')
-        #self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
+        # # Run odom, wait for odom local, global
+        # rospy.loginfo('Initializing odometry...')
+        # #self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
 
-        #_stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
-        #print(_stdout.read().decode()) #prints out the stdout of the command
+        # #_stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
+        # #print(_stdout.read().decode()) #prints out the stdout of the command
 
-        os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
-        self.wait_for_condition('odom_global_published', 35)
-        self.wait_for_condition('odom_local_published', 35)
+        # os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
+        # self.wait_for_condition('odom_global_published', 35)
+        # self.wait_for_condition('odom_local_published', 35)
 
-        rospy.loginfo('Odometry initialized.')
-        #self.close_ssh()
+        # rospy.loginfo('Odometry initialized.')
+        # #self.close_ssh()
 
         #Run cartographer
         rospy.loginfo('Starting cartographer...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python2
+#!/usr/bin/env python3
+
 import os
 import time
 import paramiko #need to install paramiko Python package
@@ -50,7 +51,6 @@ class Scheduler:
         self.assign_topic('/scan_modified', 'scan_override_set', LaserScan)
 
         #SSH
-
         self.raspberry_pi2 = "10.0.0.2" #IP Address
         self.raspberry_pi3 = "10.0.0.3" #IP Address
         self.username = "ubuntu"

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -168,12 +168,6 @@ class Scheduler:
         self.wait_for_condition('gps_started', 90)
         rospy.loginfo('Sensors launched.')
 
-        # Run utm frame transform
-        rospy.loginfo('Initializing UTM...')
-        os.system('roslaunch description utm.launch &> /dev/null &')
-        self.wait_for_transform(listener, '/map', '/utm')
-        rospy.loginfo('UTM initialized.')
-
         # override scan 
         rospy.loginfo('Launching scan override...')
         os.system('roslaunch filter_lidar_data filter_lidar_data.launch &> /dev/null &')
@@ -201,21 +195,11 @@ class Scheduler:
         rospy.loginfo('Motor controls started.')
         self.close_ssh()
 
-        #Run motor_odom_node
-
+        #Run motor_odom_node, wait for /odom
         rospy.loginfo('Starting motor_odom_node...')
         os.system('roslaunch motor_odom motor_odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_motor_published', 30)
         rospy.loginfo('motor_odom_node launched.')
-
-        #Run cartographer
-
-        rospy.loginfo('Starting cartographer...')
-        os.system('roslaunch description cartographer.launch launch_state:=IGVC &> /dev/null &')
-        self.wait_for_condition('tracked_pose_set', 60)
-        self.wait_for_transform(listener, '/odom','/base_link')
-        self.wait_for_transform(listener, '/map', '/odom')
-        rospy.loginfo('Cartographer launched.')
 
         # Run odom, wait for odom local, global, and /utm
         rospy.loginfo('Initializing odometry...')
@@ -231,6 +215,20 @@ class Scheduler:
 
         rospy.loginfo('Odometry initialized.')
         #self.close_ssh()
+
+        # Run utm frame transform
+        rospy.loginfo('Initializing UTM...')
+        os.system('roslaunch description utm.launch &> /dev/null &')
+        self.wait_for_transform(listener, '/map', '/utm')
+        rospy.loginfo('UTM initialized.')
+
+        #Run cartographer
+        rospy.loginfo('Starting cartographer...')
+        os.system('roslaunch description cartographer.launch launch_state:=IGVC &> /dev/null &')
+        self.wait_for_condition('tracked_pose_set', 60)
+        self.wait_for_transform(listener, '/odom','/base_link')
+        self.wait_for_transform(listener, '/map', '/odom')
+        rospy.loginfo('Cartographer launched.')
 
         # Run nav stack --- load_waypoints out, wait for /map /scan_modified
         rospy.loginfo('Initializing navigation stack...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -235,7 +235,7 @@ class Scheduler:
         self.wait_for_transform(listener, '/map', '/odom')
         rospy.loginfo('Cartographer launched.')
 
-        # Run nav stack --- load_waypoints out, wait for /map /scan_modified
+        # Run nav stack --- load_waypoints out, wait for /map
         rospy.loginfo('Initializing navigation stack...')
         os.system('roslaunch nav_stack move_base.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_transform(listener, '/base_link', '/map')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -124,6 +124,7 @@ class Scheduler:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
     def close_ssh(self):
+        ip_address, port = self.ssh_client.get_transport().getpeername()
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Closing SSH client to Raspberry Pi 2')
         elif ip_address == self.raspberry_pi3:

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -172,7 +172,7 @@ class Scheduler:
         self.navigate_to_folder()
 
         _stdin, _stdout, _stderr = self.ssh_client.exec_command('roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
-        print(_stdout.read().decode())
+        print(_stdout.read().decode()) #prints the stdout of the command
 
         #os.system('roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
         # self.wait_for_transform(listener, 'base_link', 'odom')
@@ -182,19 +182,18 @@ class Scheduler:
 
         # Run odom, wait for odom local, global, and /utm
         rospy.loginfo('Initializing odometry...')
-
         self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
 
         #navigate to Caffeine folder and source devel/setup.bash
         self.navigate_to_folder()
 
         _stdin, _stdout, _stderr = self.ssh_client.exec_command('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
-        print(_stdout.read().decode())
+        print(_stdout.read().decode()) #prints out the stdout of the command
 
         #os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_global_published', 35)
         self.wait_for_condition('odom_local_published', 35)
-        # self.wait_for_condition('odom_gps_published', 25)7
+        # self.wait_for_condition('odom_gps_published', 25)
 
         rospy.loginfo('Odometry initialized.')
         self.close_ssh()

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -53,10 +53,12 @@ class Scheduler:
         self.scan_override_set = False 
         #self.cv_cloud_set = False
         self.cv_lane_scan_set = False
+        self.merged_scan_set = False
         self.assign_topic('/pause_navigation', 'manual_default_set', Bool, True)
         self.assign_topic('/scan_modified', 'scan_override_set', LaserScan)
         #self.assign_topic('/cv/lane_detections_cloud','cv_cloud_set',PointCloud2)
         self.assign_topic('/cv/lane_detections_scan2','cv_lane_scan_set',LaserScan)
+        self.assign_topic('/scan_merged','cv_merged_scan_set',LaserScan)
 
         #SSH
         self.raspberry_pi2 = "10.0.0.2" #IP Address
@@ -179,6 +181,7 @@ class Scheduler:
         self.wait_for_condition('zed_started', 35)
         #self.wait_for_condition('cv_cloud_set', 30)
         self.wait_for_condition('cv_lane_scan_set', 30)
+        self.wait_for_condition('merged_scan_set', 30)
         rospy.loginfo('CV pipeline launched.')
         
         # Run motor control, teleop and feedback, wait for /odom 

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -58,7 +58,7 @@ class Scheduler:
         self.assign_topic('/scan_modified', 'scan_override_set', LaserScan)
         #self.assign_topic('/cv/lane_detections_cloud','cv_cloud_set',PointCloud2)
         self.assign_topic('/cv/lane_detections_scan2','cv_lane_scan_set',LaserScan)
-        self.assign_topic('/scan_merged','cv_merged_scan_set',LaserScan)
+        self.assign_topic('/scan_merged','merged_scan_set',LaserScan)
 
         #SSH
         self.raspberry_pi2 = "10.0.0.2" #IP Address

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -175,18 +175,18 @@ class Scheduler:
 
         # Run odom, wait for odom local, global, and /utm
         rospy.loginfo('Initializing odometry...')
-        self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
+        #self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
 
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
-        print(_stdout.read().decode()) #prints out the stdout of the command
+        #_stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
+        #print(_stdout.read().decode()) #prints out the stdout of the command
 
-        #os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
+        os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_global_published', 35)
         self.wait_for_condition('odom_local_published', 35)
         # self.wait_for_condition('odom_gps_published', 25)
 
         rospy.loginfo('Odometry initialized.')
-        self.close_ssh()
+        #self.close_ssh()
         
         # override scan 
         rospy.loginfo('Launching scan override...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -197,11 +197,11 @@ class Scheduler:
         self.wait_for_transform(listener, '/map', '/odom')
         rospy.loginfo('Cartographer launched.')
         
-        # Run motor control and feedback, wait for /odom 
+        # Run motor control, teleop and feedback, wait for /odom 
         rospy.loginfo('Starting motor controls...')
         self.initiate_ssh(self.raspberry_pi3, self.username, self.password)
 
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch motor_control teleop_motor_control.launch &> /dev/null &')
         print(_stdout.read().decode()) #prints the stdout of the command
 
         #os.system('roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
@@ -238,9 +238,9 @@ class Scheduler:
         rospy.loginfo('Waypoints loaded.') 
 
         # teleop 
-        rospy.loginfo('Starting teleop...')
-        os.system('roslaunch teleop_twist_keyboard keyboard_teleop.launch')
-        rospy.loginfo('Teleop launched.')
+        #rospy.loginfo('Starting teleop...')
+        #os.system('roslaunch teleop_twist_keyboard keyboard_teleop.launch')
+        #rospy.loginfo('Teleop launched.')
 
         return True
 

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -136,6 +136,10 @@ class Scheduler:
             rospy.loginfo('SSH client to Raspberry Pi 2 is closed')
         elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is closed')
+
+    def unsubscribe_all(self):
+        for subscriber in self.subs:
+            subscriber.unregister()
     
     def run(self):
         listener = tf.TransformListener()
@@ -245,5 +249,6 @@ if __name__=='__main__':
     scheduler = Scheduler()
     if scheduler.run():
         rospy.loginfo("Scheduler succeeded. Caffeine is ready to rumble!")
+        scheduler.unsubscribe_all()
         while not rospy.is_shutdown():
             pass

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -187,15 +187,6 @@ class Scheduler:
         self.wait_for_condition('cv_cloud_set', 30)
         self.wait_for_condition('cv_lane_scan_set', 30)
         rospy.loginfo('CV pipeline launched.')
-
-        #Run cartographer
-
-        rospy.loginfo('Starting cartographer...')
-        os.system('roslaunch description cartographer.launch launch_state:=IGVC &> /dev/null &')
-        self.wait_for_condition('tracked_pose_set', 60)
-        self.wait_for_transform(listener, '/odom','/base_link')
-        self.wait_for_transform(listener, '/map', '/odom')
-        rospy.loginfo('Cartographer launched.')
         
         # Run motor control, teleop and feedback, wait for /odom 
         rospy.loginfo('Starting motor controls...')
@@ -209,6 +200,22 @@ class Scheduler:
         # self.wait_for_condition('odom_motor_published', 30)
         rospy.loginfo('Motor controls started.')
         self.close_ssh()
+
+        #Run motor_odom_node
+
+        rospy.loginfo('Starting motor_odom_node...')
+        os.system('roslaunch motor_odom motor_odom.launch launch_state:=IGVC &> /dev/null &')
+        self.wait_for_condition('odom_motor_published', 30)
+        rospy.loginfo('motor_odom_node launched.')
+
+        #Run cartographer
+
+        rospy.loginfo('Starting cartographer...')
+        os.system('roslaunch description cartographer.launch launch_state:=IGVC &> /dev/null &')
+        self.wait_for_condition('tracked_pose_set', 60)
+        self.wait_for_transform(listener, '/odom','/base_link')
+        self.wait_for_transform(listener, '/map', '/odom')
+        rospy.loginfo('Cartographer launched.')
 
         # Run odom, wait for odom local, global, and /utm
         rospy.loginfo('Initializing odometry...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -22,17 +22,19 @@ class Scheduler:
         self.gps_started = False
         self.zed_started = False
         self.imu_started = False
-        self.lidar_started = False
+        self.lower_lidar_started = False
+        self.upper_lidar_started = False
         self.assign_topic('/gps/fix', 'gps_started', NavSatFix)
         self.assign_topic('/zed_node/rgb/image_rect_color', 'zed_started', Image)
         self.assign_topic('/imu/data', 'imu_started', Imu)
-        self.assign_topic('/scan', 'lidar_started', LaserScan)
+        self.assign_topic('/scan', 'lower_lidar_started', LaserScan)
+        self.assign_topic('/scan_upper','upper_lidar_started', LaserScan)
 
         # Frames ???? How to do this 
         self.utm_published = False
         self.map_published = False
         # self.assign_topic('/imu/data', 'imu_started', None)
-        # self.assign_topic('/scan', 'lidar_started', None)
+        # self.assign_topic('/scan', 'lower_lidar_started', None)
 
         # Odometry 
         self.odom_global_published = False
@@ -165,7 +167,8 @@ class Scheduler:
         rospy.loginfo('Starting up sensors...')
         os.system('roslaunch sensors sensors.launch launch_state:=IGVC frame_id:=gps_link &> /dev/null &')
         self.wait_for_condition('imu_started', 35)
-        self.wait_for_condition('lidar_started', 35)
+        self.wait_for_condition('lower_lidar_started', 35)
+        self.wait_for_condition('upper_lidar_started', 40)
         self.wait_for_condition('gps_started', 90)
         rospy.loginfo('Sensors launched.')
 

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -115,7 +115,7 @@ class Scheduler:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
     def navigate_to_folder(self):
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine-ws")
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine_ws")
         _stdin, _stdout, _stderr = self.ssh_client.exec_command("source devel/setup.bash")
 
     def close_ssh(self):

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -102,7 +102,7 @@ class Scheduler:
     def initiate_ssh(self, ip_address, username, password):
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Initiating SSH client to Raspberry Pi 2')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('Initiating SSH client to Raspberry Pi 3')
 
         self.ssh_client = paramiko.client.SSHClient()
@@ -111,7 +111,7 @@ class Scheduler:
 
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('SSH client to Raspberry Pi 2 is active')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
     def navigate_to_folder(self):
@@ -121,14 +121,14 @@ class Scheduler:
     def close_ssh(self):
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Closing SSH client to Raspberry Pi 2')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('Closing SSH client to Raspberry Pi 3')
 
         self.ssh_client.close()
 
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('SSH client to Raspberry Pi 2 is closed')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is closed')
     
     def run(self):

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -200,18 +200,18 @@ class Scheduler:
         rospy.loginfo('Motor controls started.')
         self.close_ssh()
 
-        # Run utm frame transform
-        rospy.loginfo('Initializing UTM...')
-        os.system('roslaunch description utm.launch &> /dev/null &')
-        self.wait_for_transform(listener, '/map', '/utm')
-        self.wait_for_condition('odom_gps_published', 25)
-        rospy.loginfo('UTM initialized.')
-
         #Run motor_odom_node, wait for /odom
         rospy.loginfo('Starting motor_odom_node...')
         os.system('roslaunch motor_odom motor_odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_motor_published', 30)
         rospy.loginfo('motor_odom_node launched.')
+
+        # Run utm frame transform,wait for odometry/gps
+        rospy.loginfo('Initializing UTM...')
+        os.system('roslaunch description utm.launch &> /dev/null &')
+        self.wait_for_transform(listener, '/map', '/utm')
+        self.wait_for_condition('odom_gps_published', 25)
+        rospy.loginfo('UTM initialized.')
 
         # Run odom, wait for odom local, global
         rospy.loginfo('Initializing odometry...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -181,7 +181,7 @@ class Scheduler:
         self.wait_for_condition('zed_started', 35)
         #self.wait_for_condition('cv_cloud_set', 30)
         self.wait_for_condition('cv_lane_scan_set', 30)
-        self.wait_for_condition('merged_scan_set', 30)
+        self.wait_for_condition('merged_scan_set', 40)
         rospy.loginfo('CV pipeline launched.')
         
         # Run motor control, teleop and feedback, wait for /odom 

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -114,10 +114,6 @@ class Scheduler:
         elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
-    def navigate_to_folder(self):
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine_ws")
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("source devel/setup.bash")
-
     def close_ssh(self):
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Closing SSH client to Raspberry Pi 2')
@@ -168,10 +164,7 @@ class Scheduler:
         rospy.loginfo('Starting motor controls...')
         self.initiate_ssh(self.raspberry_pi3, self.username, self.password)
 
-        #navigate to Caffeine folder and source devel/setup.bash
-        self.navigate_to_folder()
-
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command('roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
         print(_stdout.read().decode()) #prints the stdout of the command
 
         #os.system('roslaunch description motor_control_pipeline.launch launch_state:=IGVC &> /dev/null &')
@@ -184,10 +177,7 @@ class Scheduler:
         rospy.loginfo('Initializing odometry...')
         self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
 
-        #navigate to Caffeine folder and source devel/setup.bash
-        self.navigate_to_folder()
-
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command('cd ~/caffeine_ws && source devel/setup.bash && roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
         print(_stdout.read().decode()) #prints out the stdout of the command
 
         #os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -200,13 +200,20 @@ class Scheduler:
         rospy.loginfo('Motor controls started.')
         self.close_ssh()
 
+        # Run utm frame transform
+        rospy.loginfo('Initializing UTM...')
+        os.system('roslaunch description utm.launch &> /dev/null &')
+        self.wait_for_transform(listener, '/map', '/utm')
+        self.wait_for_condition('odom_gps_published', 25)
+        rospy.loginfo('UTM initialized.')
+
         #Run motor_odom_node, wait for /odom
         rospy.loginfo('Starting motor_odom_node...')
         os.system('roslaunch motor_odom motor_odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_motor_published', 30)
         rospy.loginfo('motor_odom_node launched.')
 
-        # Run odom, wait for odom local, global, and /utm
+        # Run odom, wait for odom local, global
         rospy.loginfo('Initializing odometry...')
         #self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
 
@@ -216,16 +223,9 @@ class Scheduler:
         os.system('roslaunch odom odom.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('odom_global_published', 35)
         self.wait_for_condition('odom_local_published', 35)
-        # self.wait_for_condition('odom_gps_published', 25)
 
         rospy.loginfo('Odometry initialized.')
         #self.close_ssh()
-
-        # Run utm frame transform
-        rospy.loginfo('Initializing UTM...')
-        os.system('roslaunch description utm.launch &> /dev/null &')
-        self.wait_for_transform(listener, '/map', '/utm')
-        rospy.loginfo('UTM initialized.')
 
         #Run cartographer
         rospy.loginfo('Starting cartographer...')

--- a/description/src/scheduler.py
+++ b/description/src/scheduler.py
@@ -51,12 +51,12 @@ class Scheduler:
         # Meta
         self.manual_default_set = False
         self.scan_override_set = False 
-        self.cv_cloud_set = False
+        #self.cv_cloud_set = False
         self.cv_lane_scan_set = False
         self.assign_topic('/pause_navigation', 'manual_default_set', Bool, True)
         self.assign_topic('/scan_modified', 'scan_override_set', LaserScan)
-        self.assign_topic('/cv/lane_detections_cloud','cv_cloud_set',PointCloud2)
-        self.assign_topic('/cv/lane_detections_scan','cv_lane_scan_set',LaserScan)
+        #self.assign_topic('/cv/lane_detections_cloud','cv_cloud_set',PointCloud2)
+        self.assign_topic('/cv/lane_detections_scan2','cv_lane_scan_set',LaserScan)
 
         #SSH
         self.raspberry_pi2 = "10.0.0.2" #IP Address
@@ -177,7 +177,7 @@ class Scheduler:
         rospy.loginfo('Starting CV pipeline...')
         os.system('roslaunch cv pipeline.launch launch_state:=IGVC &> /dev/null &')
         self.wait_for_condition('zed_started', 35)
-        self.wait_for_condition('cv_cloud_set', 30)
+        #self.wait_for_condition('cv_cloud_set', 30)
         self.wait_for_condition('cv_lane_scan_set', 30)
         rospy.loginfo('CV pipeline launched.')
         

--- a/description/src/ssh_test.py
+++ b/description/src/ssh_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import paramiko
+import rospy
+
+class SSHConnection:
+
+    def __init__(self):
+        self.node = rospy.init_node("SSH_Connection")
+        self.raspberry_pi2 = "10.0.0.2" #IP Address
+        self.raspberry_pi3 = "10.0.0.3" #IP Address
+        self.username = "ubuntu"
+        self.password = "utraart2021"
+
+    def initiate_ssh(self, ip_address, username, password):
+        if ip_address == self.raspberry_pi2:
+            rospy.loginfo('Initiating SSH client to Raspberry Pi 2')
+        else if ip_address == self.raspberry_pi3:
+            rospy.loginfo('Initiating SSH client to Raspberry Pi 3')
+
+        self.ssh_client = paramiko.client.SSHClient()
+        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh_client.connect(ip_address, username=username, password=password)
+
+        if ip_address == self.raspberry_pi2:
+            rospy.loginfo('SSH client to Raspberry Pi 2 is active')
+        else if ip_address == self.raspberry_pi3:
+            rospy.loginfo('SSH client to Raspberry Pi 3 is active')
+
+    def navigate_to_folder(self):
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine_ws")
+        print(_stdout.read().decode()) #prints out the stdout of the command
+
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command("ls")
+        print(_stdout.read().decode()) #prints out the stdout of the command
+
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command("source devel/setup.bash")
+        print(_stdout.read().decode()) #prints out the stdout of the command
+
+    def close_ssh(self):
+        if ip_address == self.raspberry_pi2:
+            rospy.loginfo('Closing SSH client to Raspberry Pi 2')
+        else if ip_address == self.raspberry_pi3:
+            rospy.loginfo('Closing SSH client to Raspberry Pi 3')
+
+        self.ssh_client.close()
+
+        if ip_address == self.raspberry_pi2:
+            rospy.loginfo('SSH client to Raspberry Pi 2 is closed')
+        else if ip_address == self.raspberry_pi3:
+            rospy.loginfo('SSH client to Raspberry Pi 3 is closed')
+        
+    def run(self):
+        self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
+        self.navigate_to_folder()
+        self.close_ssh()
+
+        self.initiate_ssh(self.raspberry_pi3, self.username, self.password)
+        self.navigate_to_folder()
+        self.close_ssh()
+
+if __name__=='__main__':
+    ssh_connection = SSH_Connection()
+    ssh_connection.run()
+    
+    while not rospy.is_shutdown():
+        pass
+

--- a/description/src/ssh_test.py
+++ b/description/src/ssh_test.py
@@ -57,7 +57,7 @@ class SSHConnection:
         self.close_ssh()
 
 if __name__=='__main__':
-    ssh_connection = SSH_Connection()
+    ssh_connection = SSHConnection()
     ssh_connection.run()
     
     while not rospy.is_shutdown():

--- a/description/src/ssh_test.py
+++ b/description/src/ssh_test.py
@@ -7,7 +7,8 @@ class SSHConnection:
 
     def __init__(self):
         self.node = rospy.init_node("SSH_Connection")
-        self.raspberry_pi2 = "10.0.0.2" #IP Address
+        #self.raspberry_pi2 = "10.0.0.2" #IP Address
+        self.raspberry_pi2 = "192.168.171.155"
         self.raspberry_pi3 = "10.0.0.3" #IP Address
         self.username = "ubuntu"
         self.password = "utraart2021"
@@ -15,7 +16,7 @@ class SSHConnection:
     def initiate_ssh(self, ip_address, username, password):
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Initiating SSH client to Raspberry Pi 2')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('Initiating SSH client to Raspberry Pi 3')
 
         self.ssh_client = paramiko.client.SSHClient()
@@ -24,7 +25,7 @@ class SSHConnection:
 
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('SSH client to Raspberry Pi 2 is active')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
     def navigate_to_folder(self):
@@ -40,14 +41,14 @@ class SSHConnection:
     def close_ssh(self):
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Closing SSH client to Raspberry Pi 2')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('Closing SSH client to Raspberry Pi 3')
 
         self.ssh_client.close()
 
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('SSH client to Raspberry Pi 2 is closed')
-        else if ip_address == self.raspberry_pi3:
+        elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is closed')
         
     def run(self):

--- a/description/src/ssh_test.py
+++ b/description/src/ssh_test.py
@@ -55,10 +55,6 @@ class SSHConnection:
         self.navigate_to_folder()
         self.close_ssh()
 
-        self.initiate_ssh(self.raspberry_pi3, self.username, self.password)
-        self.navigate_to_folder()
-        self.close_ssh()
-
 if __name__=='__main__':
     ssh_connection = SSH_Connection()
     ssh_connection.run()

--- a/description/src/ssh_test.py
+++ b/description/src/ssh_test.py
@@ -28,17 +28,8 @@ class SSHConnection:
         elif ip_address == self.raspberry_pi3:
             rospy.loginfo('SSH client to Raspberry Pi 3 is active')
 
-    def navigate_to_folder(self):
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine_ws")
-        print(_stdout.read().decode()) #prints out the stdout of the command
-
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("ls")
-        print(_stdout.read().decode()) #prints out the stdout of the command
-
-        _stdin, _stdout, _stderr = self.ssh_client.exec_command("source devel/setup.bash")
-        print(_stdout.read().decode()) #prints out the stdout of the command
-
     def close_ssh(self):
+        ip_address, port = self.ssh_client.get_transport().getpeername()
         if ip_address == self.raspberry_pi2:
             rospy.loginfo('Closing SSH client to Raspberry Pi 2')
         elif ip_address == self.raspberry_pi3:
@@ -53,7 +44,8 @@ class SSHConnection:
         
     def run(self):
         self.initiate_ssh(self.raspberry_pi2, self.username, self.password)
-        self.navigate_to_folder()
+        _stdin, _stdout, _stderr = self.ssh_client.exec_command("cd ~/caffeine_ws && ls && source devel/setup.bash")
+        print(_stdout.read().decode()) #prints the stdout of the command
         self.close_ssh()
 
 if __name__=='__main__':

--- a/description/urdf/constants.xacro
+++ b/description/urdf/constants.xacro
@@ -46,7 +46,7 @@
     <xacro:property name="wheel_right_joint" value="right_wheel_joint"/>
 
     <!--<xacro:property name="wheels_separation" value="0.875"/>-->
-    <xacro:property name="wheels_separation" value="0.926"/>
+    <xacro:property name="wheels_separation" value="0.916"/>
     <xacro:property name="wheel_diameter" value="0.25"/>
 
     <xacro:property name="wheel_acceleration" value="1.0"/>

--- a/motor/motor_control/src/cmd_vel_to_motor.cpp
+++ b/motor/motor_control/src/cmd_vel_to_motor.cpp
@@ -5,7 +5,7 @@
 
 double g_vx = 0.0;
 double g_wz = 0.0;
-const double WHEELBASE = 0.926; //0.89; // meters
+const double WHEELBASE = 0.916; //0.89; // meters
 
 // For more info see https://www.ato.com/Content/doc/ATO-BLD750-BLDC-motor-controller-specs.pdf 
 const double FACTOR = 1 / .447 * 5280 * 12 / 10 / 3.1415 / 60 * 16; // M/s to rpm (before gearbox) 

--- a/odom/config/odom_global.yaml
+++ b/odom/config/odom_global.yaml
@@ -9,7 +9,7 @@ base_link_frame: base_link
 world_frame: map
 
 # publish transform: world_frame --> odom_frame
-publish_tf: true
+publish_tf: false
 
 transform_time_offset: 0.05
 

--- a/odom/config/odom_local.yaml
+++ b/odom/config/odom_local.yaml
@@ -9,7 +9,7 @@ base_link_frame: base_link
 world_frame: odom
 
 # publish transform: world_frame --> base_link_frame
-publish_tf: true
+publish_tf: false
 
 transform_time_offset: 0.05
 

--- a/odom/launch/odom.launch
+++ b/odom/launch/odom.launch
@@ -22,7 +22,7 @@
     <!-- In scheduler, utm.launch is used. So this is only launched for sim -->
     <group if="$(eval launch_state == 'sim')">
         <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" respawn="true">
-            <remap from="odometry/filtered" to="odometry/global"/>
+            <remap from="odometry/filtered" to="odometry/gps"/>
 
             <rosparam command="load" file="$(find odom)/config/navsat.yaml"/>
         </node>


### PR DESCRIPTION
**Scheduler Updates:**
- Added ssh for raspberry pi(s) - must download paramiko to run
- Added launch for cartographer
- Reordering to enable cartographer and odom to launch correctly
- If scheduler runs successfully, the node will now unsubscribe from all topics it was previously checking - it no longer needs to monitor the topics.

**Wheel Separation Updates:**
- Caffeine was modified at IGVC - wheel separation decreased from 92.6 cm to 91.6 cm