### PR TITLE
Corrected GPS Offset for 'Ramp end' and 'End of No-Man's Land'

### DIFF
--- a/nav/load_waypoints/scripts/static_waypoints_pavement.json
+++ b/nav/load_waypoints/scripts/static_waypoints_pavement.json
@@ -26,7 +26,7 @@
         {
             "id" : 2,
             "longitude" :-79.3901971,
-            "latitude" :43.6571525,
+            "latitude" :43.657141,
             "description"  : "Ramp ends",
             "test_loc_description": "Ramp End",
             "frame_id" : "map",
@@ -36,8 +36,8 @@
         {
             
             "id" : 3,
-            "longitude" :-79.39001207,
-            "latitude" :43.65715932,
+            "longitude" :-79.39004,
+            "latitude" :43.65715,
             "description"  : "End of No-Man's Land",
             "test_loc_description": "End of No-Man's Land",
             "frame_id" : "map",


### PR DESCRIPTION
Previously, the way points are set incorrectly in simulation, and results in the wrong goal being set during autonav. This PR hard codes the gps offset and places way points of "Ramp end" and "End of No-man Land" for world set in "full". 

- Executed with ramp removed in Gazebo. 
- Hard coding is only a work around, it provides stable simulation settings for goal setting. 
- The process of finding the root cause to this offset is still in progress